### PR TITLE
[server] Fix singleton translation returning incorrect content

### DIFF
--- a/packages/server/src/routes/data.ts
+++ b/packages/server/src/routes/data.ts
@@ -317,9 +317,9 @@ export function createDataRoutes(config: EditorialConfig, storage: Storage) {
         const messages = await storage.getLocalisationMessages(lang);
 
         for (const [key, message] of Object.entries(messages)) {
-          const [, typeKey, fieldKey] = key.split(".");
+          const [contentKey, typeKey, fieldKey] = key.split(".");
 
-          if (typeKey === id) {
+          if (contentKey === itemType && typeKey === id) {
             item[fieldKey] = (message as any).defaultMessage;
           }
         }


### PR DESCRIPTION
This PR fixes an issue where, when requesting the translation for a singleton item (`default` id), the returned content does not correspond to the item.

This can be tested by comparing the result of a request to:
`/api/v1/data/{itemType}/default?lang=es_ES`
and
`/api/v1/data/{itemType}?lang=es_ES`
