### PR TITLE
[admin] Fix allow clearing optional dates and add clear button DatePicker/DateTimePicker

### DIFF
--- a/packages/admin/app/components/itemForm.tsx
+++ b/packages/admin/app/components/itemForm.tsx
@@ -380,28 +380,28 @@ export default function ItemForm({
                               field.value ? new Date(field.value) : undefined
                             }
                             onDateChange={(date) => {
-                              field.onChange(
-                                date ? date.toISOString() : undefined,
-                              );
+                              field.onChange(date ? date.toISOString() : "");
                             }}
                             placeholder={value.placeholder ?? "Select date"}
+                            allowClear={value.optional}
                           />
                         ) : value.type === "datetime" ? (
-                          <DateTimePicker
-                            id={key}
-                            {...form.register(key)}
-                            date={
-                              field.value ? new Date(field.value) : undefined
-                            }
-                            onDateTimeChange={(date) => {
-                              field.onChange(
-                                date ? date.toISOString() : undefined,
-                              );
-                            }}
-                            placeholder={
-                              value.placeholder ?? "Select date and time"
-                            }
-                          />
+                          <div className="relative">
+                            <DateTimePicker
+                              id={key}
+                              {...form.register(key)}
+                              date={
+                                field.value ? new Date(field.value) : undefined
+                              }
+                              onDateTimeChange={(date) => {
+                                field.onChange(date ? date.toISOString() : "");
+                              }}
+                              placeholder={
+                                value.placeholder ?? "Select date and time"
+                              }
+                              allowClear={value.optional}
+                            />
+                          </div>
                         ) : value.type === "color" ? (
                           <ColorPicker
                             value={field.value}

--- a/packages/admin/app/components/ui/clear-button.tsx
+++ b/packages/admin/app/components/ui/clear-button.tsx
@@ -1,0 +1,27 @@
+import { X } from "lucide-react";
+
+const ClearButton = ({
+  onClear,
+  visible = true,
+}: {
+  onClear: () => void;
+  visible?: boolean;
+}) => {
+  if (!visible) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={(ev) => {
+        ev.stopPropagation();
+        onClear();
+      }}
+      className="absolute right-1 top-1/2 -translate-y-1/2 p-1 rounded"
+      title="Clear"
+    >
+      <X className="w-4 h-4 text-gray-500 hover:text-black" />
+    </button>
+  );
+};
+
+export default ClearButton;

--- a/packages/admin/app/components/ui/date-picker.tsx
+++ b/packages/admin/app/components/ui/date-picker.tsx
@@ -8,6 +8,7 @@ import {
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import { Calendar as CalendarIcon } from "lucide-react";
+import ClearButton from "./clear-button";
 
 interface DatePickerProps {
   id?: string;
@@ -16,6 +17,7 @@ interface DatePickerProps {
   placeholder?: string;
   disabled?: boolean;
   className?: string;
+  allowClear?: boolean;
 }
 
 export default function DatePicker({
@@ -25,6 +27,7 @@ export default function DatePicker({
   placeholder = "Pick a date",
   disabled = false,
   className,
+  allowClear = false,
 }: DatePickerProps) {
   return (
     <Popover>
@@ -32,14 +35,22 @@ export default function DatePicker({
         <Button
           variant={"outline"}
           className={cn(
-            "w-full justify-start text-left font-normal",
+            "w-full justify-start text-left font-normal relative",
             !date && "text-muted-foreground",
             className,
           )}
           disabled={disabled}
         >
-          <CalendarIcon className="mr-2 h-4 w-4" />
-          {date ? format(date, "PPP") : <span>{placeholder}</span>}
+          <>
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {date ? format(date, "PPP") : <span>{placeholder}</span>}
+            <ClearButton
+              onClear={() => {
+                onDateChange?.(undefined);
+              }}
+              visible={allowClear && !!date}
+            />
+          </>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0">

--- a/packages/admin/app/components/ui/datetime-picker.tsx
+++ b/packages/admin/app/components/ui/datetime-picker.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import { Calendar as CalendarIcon } from "lucide-react";
 import * as React from "react";
+import ClearButton from "./clear-button";
 
 interface DateTimePickerProps {
   id?: string;
@@ -18,6 +19,7 @@ interface DateTimePickerProps {
   placeholder?: string;
   disabled?: boolean;
   className?: string;
+  allowClear?: boolean;
 }
 
 export default function DateTimePicker({
@@ -27,6 +29,7 @@ export default function DateTimePicker({
   placeholder = "Pick a date and time",
   disabled = false,
   className,
+  allowClear = false,
 }: DateTimePickerProps) {
   const [selectedDate, setSelectedDate] = React.useState<Date | undefined>(
     date,
@@ -82,18 +85,27 @@ export default function DateTimePicker({
           <Button
             variant={"outline"}
             className={cn(
-              "flex-1 justify-start text-left font-normal",
+              "flex-1 justify-start text-left font-normal relative",
               !selectedDate && "text-muted-foreground",
               className,
             )}
             disabled={disabled}
           >
-            <CalendarIcon className="mr-2 h-4 w-4" />
-            {selectedDate ? (
-              format(selectedDate, "PPP")
-            ) : (
-              <span>{placeholder}</span>
-            )}
+            <>
+              <CalendarIcon className="mr-2 h-4 w-4" />
+              {selectedDate ? (
+                format(selectedDate, "PPP")
+              ) : (
+                <span>{placeholder}</span>
+              )}
+              <ClearButton
+                onClear={() => {
+                  setSelectedDate(undefined);
+                  onDateTimeChange?.(undefined);
+                }}
+                visible={allowClear && !!date}
+              />
+            </>
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0">


### PR DESCRIPTION
This PR fixes the issue where clearing a selected or previously saved **optional date** was not possible.  
Now, optional dates can be deselected or cleared using a Lucide X button inside the DatePicker and DateTimePicker components.

Closes #23 
