### PR TITLE
[admin] Add allowfreeintput in select and multiselect inputs

### DIFF
--- a/packages/admin/app/components/itemForm.tsx
+++ b/packages/admin/app/components/itemForm.tsx
@@ -83,6 +83,72 @@ export interface SinglesPageProps {
   itemStatus?: EditorialDataItemStatus;
 }
 
+type SchemaField = EditorialSchemaItem["fields"][string];
+
+const getSelectFieldState = (
+  field: SchemaField,
+  resolvedChoices: string[],
+  inputText: string,
+) => {
+  const allowFreeInput =
+    field.type === "select" && field.allowFreeInput === true;
+  const hasChoicesConfigured =
+    field.type === "select" &&
+    Array.isArray(field.choicesFixed) &&
+    field.choicesFixed.length > 0;
+
+  return {
+    shouldOnlyDropdown: field.type === "select" && !allowFreeInput,
+    shouldMixedDropdown:
+      field.type === "select" && allowFreeInput && hasChoicesConfigured,
+    shouldOnlyTyping:
+      field.type === "select" && allowFreeInput && !hasChoicesConfigured,
+    filteredChoices: resolvedChoices.filter((choice) =>
+      choice.toLowerCase().includes(inputText.toLowerCase()),
+    ),
+    canCreateFromInput: inputText.trim().length > 0,
+  };
+};
+
+const getMultiselectFieldState = (
+  field: SchemaField,
+  resolvedChoices: string[],
+  selectedValues: string[],
+  inputText: string,
+) => {
+  const allowFreeInput =
+    field.type === "multiselect" && field.allowFreeInput === true;
+  const hasChoicesConfigured =
+    field.type === "multiselect" &&
+    Array.isArray(field.choicesFixed) &&
+    field.choicesFixed.length > 0;
+  const availableChoices = resolvedChoices.filter(
+    (choice) => !selectedValues.includes(choice),
+  );
+
+  return {
+    shouldOnlyDropdown: field.type === "multiselect" && !allowFreeInput,
+    shouldMixedDropdown:
+      field.type === "multiselect" && allowFreeInput && hasChoicesConfigured,
+    shouldOnlyTyping:
+      field.type === "multiselect" && allowFreeInput && !hasChoicesConfigured,
+    availableChoices,
+    filteredChoices: availableChoices.filter((choice) =>
+      choice.toLowerCase().includes(inputText.toLowerCase()),
+    ),
+    canCreateFromInput:
+      inputText.trim().length > 0 &&
+      !selectedValues.includes(inputText.trim()) &&
+      (!field.maxSelectedChoices ||
+        selectedValues.length < field.maxSelectedChoices),
+  };
+};
+
+const hasSelectionMinMax = (field: SchemaField) =>
+  (field.type === "multiselect" ||
+    (field.type === "string" && field.isMultiple && field.choicesFixed)) &&
+  (field.minSelectedChoices || field.maxSelectedChoices);
+
 export default function ItemForm({
   itemType,
   fields,
@@ -108,6 +174,12 @@ export default function ItemForm({
     Record<string, boolean>
   >({});
   const [multiselectInputState, setMultiselectInputState] = useState<
+    Record<string, string>
+  >({});
+  const [selectOpenState, setSelectOpenState] = useState<
+    Record<string, boolean>
+  >({});
+  const [selectInputState, setSelectInputState] = useState<
     Record<string, string>
   >({});
 
@@ -196,7 +268,9 @@ export default function ItemForm({
         case "select":
           // For referenced choices, use string validation instead of enum
           // since the choices are dynamic
-          if (getChoicesReference(field.choicesFixed)) {
+          if (field.allowFreeInput) {
+            fieldSchema = z.string();
+          } else if (getChoicesReference(field.choicesFixed)) {
             fieldSchema = z.string();
           } else if (field.choicesFixed && field.choicesFixed.length > 0) {
             fieldSchema = z.enum(field.choicesFixed as [string, ...string[]]);
@@ -512,6 +586,20 @@ export default function ItemForm({
     [],
   );
 
+  const updateSelectInput = React.useCallback(
+    (fieldKey: string, value: string) => {
+      setSelectInputState((prev) => ({ ...prev, [fieldKey]: value }));
+    },
+    [],
+  );
+
+  const updateSelectOpen = React.useCallback(
+    (fieldKey: string, open: boolean) => {
+      setSelectOpenState((prev) => ({ ...prev, [fieldKey]: open }));
+    },
+    [],
+  );
+
   const ModifiedMessage = ({ fieldKey }: { fieldKey: string }) => (
     <span className="inline-flex items-center gap-1 text-yellow-800 text-xs">
       (modified)
@@ -728,44 +816,22 @@ export default function ItemForm({
                     required: !value.optional,
                   }}
                   render={({ field }) => {
-                    const selectedCount =
-                      (field.value as string[])?.length ?? 0;
                     const selectedValues = (field.value as string[]) ?? [];
-                    const allowFreeInput =
-                      value.type === "multiselect" &&
-                      value.allowFreeInput === true;
-                    const hasChoicesConfigured =
-                      value.type === "multiselect" &&
-                      Array.isArray(value.choicesFixed) &&
-                      value.choicesFixed.length > 0;
-                    const shouldShowOnlyDropdown =
-                      value.type === "multiselect" && !allowFreeInput;
-                    const shouldShowMixedDropdown =
-                      value.type === "multiselect" &&
-                      allowFreeInput &&
-                      hasChoicesConfigured;
-                    const shouldShowOnlyTyping =
-                      value.type === "multiselect" &&
-                      allowFreeInput &&
-                      !hasChoicesConfigured;
-                    const availableChoices = resolvedChoices.filter(
-                      (choice) => !selectedValues.includes(choice),
+                    const selectedCount = selectedValues.length;
+                    const selectInputText = selectInputState[key] ?? "";
+                    const selectState = getSelectFieldState(
+                      value,
+                      resolvedChoices,
+                      selectInputText,
                     );
                     const inputText = multiselectInputState[key] ?? "";
-                    const filteredChoices = availableChoices.filter((choice) =>
-                      choice.toLowerCase().includes(inputText.toLowerCase()),
+                    const multiselectState = getMultiselectFieldState(
+                      value,
+                      resolvedChoices,
+                      selectedValues,
+                      inputText,
                     );
-                    const canCreateFromInput =
-                      inputText.trim().length > 0 &&
-                      !selectedValues.includes(inputText.trim()) &&
-                      (!value.maxSelectedChoices ||
-                        selectedValues.length < value.maxSelectedChoices);
-                    const hasMinMax =
-                      (value.type === "multiselect" ||
-                        (value.type === "string" &&
-                          value.isMultiple &&
-                          value.choicesFixed)) &&
-                      (value.minSelectedChoices || value.maxSelectedChoices);
+                    const hasMinMax = hasSelectionMinMax(value);
 
                     return (
                       <FormItem
@@ -874,25 +940,114 @@ export default function ItemForm({
                             />
                           ) : value.type === "select" ? (
                             <div className="flex gap-2">
-                              <Select
-                                value={field.value as string}
-                                onValueChange={field.onChange}
-                              >
-                                <SelectTrigger id={key} className="w-full">
-                                  <SelectValue
-                                    placeholder={
-                                      value.placeholder ?? "Select an item..."
-                                    }
-                                  />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {resolvedChoices.map((choice) => (
-                                    <SelectItem key={choice} value={choice}>
-                                      {choice}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
+                              {selectState.shouldOnlyDropdown && (
+                                <Select
+                                  value={field.value as string}
+                                  onValueChange={field.onChange}
+                                >
+                                  <SelectTrigger id={key} className="w-full">
+                                    <SelectValue
+                                      placeholder={
+                                        value.placeholder ?? "Select an item..."
+                                      }
+                                    />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {resolvedChoices.map((choice) => (
+                                      <SelectItem key={choice} value={choice}>
+                                        {choice}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              )}
+
+                              {selectState.shouldMixedDropdown && (
+                                <Popover
+                                  open={selectOpenState[key] ?? false}
+                                  onOpenChange={(open) =>
+                                    updateSelectOpen(key, open)
+                                  }
+                                >
+                                  <PopoverTrigger asChild>
+                                    <Button
+                                      id={key}
+                                      type="button"
+                                      variant="outline"
+                                      role="combobox"
+                                      aria-expanded={
+                                        selectOpenState[key] ?? false
+                                      }
+                                      className="w-full justify-between"
+                                    >
+                                      {(field.value as string) ||
+                                        value.placeholder ||
+                                        "Select or type..."}
+                                      <ChevronsUpDown className="opacity-50" />
+                                    </Button>
+                                  </PopoverTrigger>
+                                  <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
+                                    <Command>
+                                      <CommandInput
+                                        value={selectInputText}
+                                        onValueChange={(newValue) =>
+                                          updateSelectInput(key, newValue)
+                                        }
+                                        onKeyDown={(event) => {
+                                          if (event.key !== "Enter") return;
+
+                                          event.preventDefault();
+                                          if (!selectState.canCreateFromInput)
+                                            return;
+
+                                          field.onChange(
+                                            selectInputText.trim(),
+                                          );
+                                          updateSelectInput(key, "");
+                                          updateSelectOpen(key, false);
+                                        }}
+                                        placeholder="Select or type to add..."
+                                      />
+                                      <CommandList>
+                                        <CommandEmpty>
+                                          {selectState.canCreateFromInput
+                                            ? `Press Enter to use \"${selectInputText.trim()}\"`
+                                            : "No available items"}
+                                        </CommandEmpty>
+                                        <CommandGroup>
+                                          {selectState.filteredChoices.map(
+                                            (choice) => (
+                                              <CommandItem
+                                                key={choice}
+                                                value={choice}
+                                                onSelect={() => {
+                                                  field.onChange(choice);
+                                                  updateSelectInput(key, "");
+                                                  updateSelectOpen(key, false);
+                                                }}
+                                              >
+                                                {choice}
+                                              </CommandItem>
+                                            ),
+                                          )}
+                                        </CommandGroup>
+                                      </CommandList>
+                                    </Command>
+                                  </PopoverContent>
+                                </Popover>
+                              )}
+
+                              {selectState.shouldOnlyTyping && (
+                                <Input
+                                  id={key}
+                                  placeholder={
+                                    value.placeholder ?? "Type a value..."
+                                  }
+                                  {...field}
+                                  value={field.value as string}
+                                />
+                              )}
+
                               {value.optional && field.value && (
                                 <Button
                                   type="button"
@@ -945,7 +1100,7 @@ export default function ItemForm({
                               {(!value.maxSelectedChoices ||
                                 selectedCount < value.maxSelectedChoices) && (
                                 <>
-                                  {shouldShowOnlyDropdown && (
+                                  {multiselectState.shouldOnlyDropdown && (
                                     <Select
                                       value=""
                                       onValueChange={(newValue) => {
@@ -973,19 +1128,21 @@ export default function ItemForm({
                                         />
                                       </SelectTrigger>
                                       <SelectContent>
-                                        {availableChoices.map((choice) => (
-                                          <SelectItem
-                                            key={choice}
-                                            value={choice}
-                                          >
-                                            {choice}
-                                          </SelectItem>
-                                        ))}
+                                        {multiselectState.availableChoices.map(
+                                          (choice) => (
+                                            <SelectItem
+                                              key={choice}
+                                              value={choice}
+                                            >
+                                              {choice}
+                                            </SelectItem>
+                                          ),
+                                        )}
                                       </SelectContent>
                                     </Select>
                                   )}
 
-                                  {shouldShowMixedDropdown && (
+                                  {multiselectState.shouldMixedDropdown && (
                                     <Popover
                                       open={multiselectOpenState[key] ?? false}
                                       onOpenChange={(open) =>
@@ -1020,7 +1177,10 @@ export default function ItemForm({
                                               if (event.key !== "Enter") return;
 
                                               event.preventDefault();
-                                              if (!canCreateFromInput) return;
+                                              if (
+                                                !multiselectState.canCreateFromInput
+                                              )
+                                                return;
 
                                               const nextValues =
                                                 addMultiselectValue(
@@ -1040,40 +1200,42 @@ export default function ItemForm({
                                           />
                                           <CommandList>
                                             <CommandEmpty>
-                                              {canCreateFromInput
+                                              {multiselectState.canCreateFromInput
                                                 ? `Press Enter to add \"${inputText.trim()}\"`
                                                 : "No available items"}
                                             </CommandEmpty>
                                             <CommandGroup>
-                                              {filteredChoices.map((choice) => (
-                                                <CommandItem
-                                                  key={choice}
-                                                  value={choice}
-                                                  onSelect={() => {
-                                                    const nextValues =
-                                                      addMultiselectValue(
-                                                        selectedValues,
-                                                        choice,
-                                                        value.maxSelectedChoices,
-                                                      );
+                                              {multiselectState.filteredChoices.map(
+                                                (choice) => (
+                                                  <CommandItem
+                                                    key={choice}
+                                                    value={choice}
+                                                    onSelect={() => {
+                                                      const nextValues =
+                                                        addMultiselectValue(
+                                                          selectedValues,
+                                                          choice,
+                                                          value.maxSelectedChoices,
+                                                        );
 
-                                                    if (
-                                                      nextValues !==
-                                                      selectedValues
-                                                    ) {
-                                                      field.onChange(
-                                                        nextValues,
+                                                      if (
+                                                        nextValues !==
+                                                        selectedValues
+                                                      ) {
+                                                        field.onChange(
+                                                          nextValues,
+                                                        );
+                                                      }
+                                                      updateMultiselectInput(
+                                                        key,
+                                                        "",
                                                       );
-                                                    }
-                                                    updateMultiselectInput(
-                                                      key,
-                                                      "",
-                                                    );
-                                                  }}
-                                                >
-                                                  {choice}
-                                                </CommandItem>
-                                              ))}
+                                                    }}
+                                                  >
+                                                    {choice}
+                                                  </CommandItem>
+                                                ),
+                                              )}
                                             </CommandGroup>
                                           </CommandList>
                                         </Command>
@@ -1081,7 +1243,7 @@ export default function ItemForm({
                                     </Popover>
                                   )}
 
-                                  {shouldShowOnlyTyping && (
+                                  {multiselectState.shouldOnlyTyping && (
                                     <Input
                                       id={`${key}-custom-item`}
                                       placeholder={

--- a/packages/admin/app/components/itemForm.tsx
+++ b/packages/admin/app/components/itemForm.tsx
@@ -12,6 +12,14 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
   Form,
   FormControl,
   FormDescription,
@@ -21,6 +29,11 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -43,7 +56,7 @@ import {
   type EditorialDataItemStatus,
   type EditorialSchemaItem,
 } from "@isardsat/editorial-common";
-import { Loader2, RotateCcw, Save, X } from "lucide-react";
+import { ChevronsUpDown, Loader2, RotateCcw, Save, X } from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
@@ -91,6 +104,12 @@ export default function ItemForm({
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmMode, setConfirmMode] = useState<"single" | "all" | null>(null);
   const [pendingFieldKey, setPendingFieldKey] = useState<string | null>(null);
+  const [multiselectOpenState, setMultiselectOpenState] = useState<
+    Record<string, boolean>
+  >({});
+  const [multiselectInputState, setMultiselectInputState] = useState<
+    Record<string, string>
+  >({});
 
   const isFieldChanged = (fieldKey: string) => changedFields.includes(fieldKey);
 
@@ -460,6 +479,39 @@ export default function ItemForm({
   const changedFieldStyles =
     "outline outline-1 outline-yellow-400 outline-offset-4 rounded-sm";
 
+  const addMultiselectValue = React.useCallback(
+    (
+      currentValues: string[],
+      rawValue: string,
+      maxSelectedChoices?: number,
+    ) => {
+      const nextValue = rawValue.trim();
+
+      if (!nextValue) return currentValues;
+      if (currentValues.includes(nextValue)) return currentValues;
+      if (maxSelectedChoices && currentValues.length >= maxSelectedChoices) {
+        return currentValues;
+      }
+
+      return [...currentValues, nextValue];
+    },
+    [],
+  );
+
+  const updateMultiselectInput = React.useCallback(
+    (fieldKey: string, value: string) => {
+      setMultiselectInputState((prev) => ({ ...prev, [fieldKey]: value }));
+    },
+    [],
+  );
+
+  const updateMultiselectOpen = React.useCallback(
+    (fieldKey: string, open: boolean) => {
+      setMultiselectOpenState((prev) => ({ ...prev, [fieldKey]: open }));
+    },
+    [],
+  );
+
   const ModifiedMessage = ({ fieldKey }: { fieldKey: string }) => (
     <span className="inline-flex items-center gap-1 text-yellow-800 text-xs">
       (modified)
@@ -678,6 +730,36 @@ export default function ItemForm({
                   render={({ field }) => {
                     const selectedCount =
                       (field.value as string[])?.length ?? 0;
+                    const selectedValues = (field.value as string[]) ?? [];
+                    const allowFreeInput =
+                      value.type === "multiselect" &&
+                      value.allowFreeInput === true;
+                    const hasChoicesConfigured =
+                      value.type === "multiselect" &&
+                      Array.isArray(value.choicesFixed) &&
+                      value.choicesFixed.length > 0;
+                    const shouldShowOnlyDropdown =
+                      value.type === "multiselect" && !allowFreeInput;
+                    const shouldShowMixedDropdown =
+                      value.type === "multiselect" &&
+                      allowFreeInput &&
+                      hasChoicesConfigured;
+                    const shouldShowOnlyTyping =
+                      value.type === "multiselect" &&
+                      allowFreeInput &&
+                      !hasChoicesConfigured;
+                    const availableChoices = resolvedChoices.filter(
+                      (choice) => !selectedValues.includes(choice),
+                    );
+                    const inputText = multiselectInputState[key] ?? "";
+                    const filteredChoices = availableChoices.filter((choice) =>
+                      choice.toLowerCase().includes(inputText.toLowerCase()),
+                    );
+                    const canCreateFromInput =
+                      inputText.trim().length > 0 &&
+                      !selectedValues.includes(inputText.trim()) &&
+                      (!value.maxSelectedChoices ||
+                        selectedValues.length < value.maxSelectedChoices);
                     const hasMinMax =
                       (value.type === "multiselect" ||
                         (value.type === "string" &&
@@ -829,73 +911,202 @@ export default function ItemForm({
                           ) : value.type === "multiselect" ? (
                             <div className="flex flex-col gap-2">
                               <div className="flex flex-wrap gap-2 min-h-[38px] p-2 border rounded-md bg-background">
-                                {(field.value as string[])?.length > 0 ? (
-                                  (field.value as string[]).map(
-                                    (selectedValue) => (
-                                      <span
-                                        key={selectedValue}
-                                        className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-sm font-medium bg-gray-100 text-black-800"
-                                      >
-                                        {selectedValue}
-                                        <button
-                                          type="button"
-                                          onClick={() => {
-                                            const newValues = (
-                                              field.value as string[]
-                                            ).filter(
+                                {selectedValues.length > 0 ? (
+                                  selectedValues.map((selectedValue) => (
+                                    <span
+                                      key={selectedValue}
+                                      className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-sm font-medium bg-gray-100 text-black-800"
+                                    >
+                                      {selectedValue}
+                                      <button
+                                        type="button"
+                                        onClick={() => {
+                                          const newValues =
+                                            selectedValues.filter(
                                               (v) => v !== selectedValue,
                                             );
-                                            field.onChange(newValues);
-                                          }}
-                                          className="hover:bg-gray-200 rounded-sm p-0.5"
-                                        >
-                                          <X size={14} />
-                                          <span className="sr-only">
-                                            Remove {selectedValue}
-                                          </span>
-                                        </button>
-                                      </span>
-                                    ),
-                                  )
+                                          field.onChange(newValues);
+                                        }}
+                                        className="hover:bg-gray-200 rounded-sm p-0.5"
+                                      >
+                                        <X size={14} />
+                                        <span className="sr-only">
+                                          Remove {selectedValue}
+                                        </span>
+                                      </button>
+                                    </span>
+                                  ))
                                 ) : (
                                   <span className="text-muted-foreground text-sm">
-                                    {value.placeholder ?? "Select items..."}
+                                    {value.placeholder ?? "Add items..."}
                                   </span>
                                 )}
                               </div>
                               {(!value.maxSelectedChoices ||
                                 selectedCount < value.maxSelectedChoices) && (
-                                <Select
-                                  value=""
-                                  onValueChange={(newValue) => {
-                                    const currentValues =
-                                      (field.value as string[]) || [];
-                                    if (!currentValues.includes(newValue)) {
-                                      field.onChange([
-                                        ...currentValues,
-                                        newValue,
-                                      ]);
-                                    }
-                                  }}
-                                >
-                                  <SelectTrigger id={key} className="w-full">
-                                    <SelectValue placeholder="Add item..." />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    {resolvedChoices
-                                      .filter(
-                                        (choice) =>
-                                          !(field.value as string[])?.includes(
-                                            choice,
-                                          ),
-                                      )
-                                      .map((choice) => (
-                                        <SelectItem key={choice} value={choice}>
-                                          {choice}
-                                        </SelectItem>
-                                      ))}
-                                  </SelectContent>
-                                </Select>
+                                <>
+                                  {shouldShowOnlyDropdown && (
+                                    <Select
+                                      value=""
+                                      onValueChange={(newValue) => {
+                                        const currentValues = selectedValues;
+                                        const nextValues = addMultiselectValue(
+                                          currentValues,
+                                          newValue,
+                                          value.maxSelectedChoices,
+                                        );
+
+                                        if (nextValues !== currentValues) {
+                                          field.onChange(nextValues);
+                                        }
+                                      }}
+                                    >
+                                      <SelectTrigger
+                                        id={key}
+                                        className="w-full"
+                                      >
+                                        <SelectValue
+                                          placeholder={
+                                            value.placeholder ??
+                                            "Select item..."
+                                          }
+                                        />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        {availableChoices.map((choice) => (
+                                          <SelectItem
+                                            key={choice}
+                                            value={choice}
+                                          >
+                                            {choice}
+                                          </SelectItem>
+                                        ))}
+                                      </SelectContent>
+                                    </Select>
+                                  )}
+
+                                  {shouldShowMixedDropdown && (
+                                    <Popover
+                                      open={multiselectOpenState[key] ?? false}
+                                      onOpenChange={(open) =>
+                                        updateMultiselectOpen(key, open)
+                                      }
+                                    >
+                                      <PopoverTrigger asChild>
+                                        <Button
+                                          type="button"
+                                          variant="outline"
+                                          role="combobox"
+                                          aria-expanded={
+                                            multiselectOpenState[key] ?? false
+                                          }
+                                          className="w-full justify-between"
+                                        >
+                                          {value.placeholder ?? "Add item..."}
+                                          <ChevronsUpDown className="opacity-50" />
+                                        </Button>
+                                      </PopoverTrigger>
+                                      <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
+                                        <Command>
+                                          <CommandInput
+                                            value={inputText}
+                                            onValueChange={(newValue) =>
+                                              updateMultiselectInput(
+                                                key,
+                                                newValue,
+                                              )
+                                            }
+                                            onKeyDown={(event) => {
+                                              if (event.key !== "Enter") return;
+
+                                              event.preventDefault();
+                                              if (!canCreateFromInput) return;
+
+                                              const nextValues =
+                                                addMultiselectValue(
+                                                  selectedValues,
+                                                  inputText,
+                                                  value.maxSelectedChoices,
+                                                );
+
+                                              if (
+                                                nextValues !== selectedValues
+                                              ) {
+                                                field.onChange(nextValues);
+                                                updateMultiselectInput(key, "");
+                                              }
+                                            }}
+                                            placeholder="Select or type to add..."
+                                          />
+                                          <CommandList>
+                                            <CommandEmpty>
+                                              {canCreateFromInput
+                                                ? `Press Enter to add \"${inputText.trim()}\"`
+                                                : "No available items"}
+                                            </CommandEmpty>
+                                            <CommandGroup>
+                                              {filteredChoices.map((choice) => (
+                                                <CommandItem
+                                                  key={choice}
+                                                  value={choice}
+                                                  onSelect={() => {
+                                                    const nextValues =
+                                                      addMultiselectValue(
+                                                        selectedValues,
+                                                        choice,
+                                                        value.maxSelectedChoices,
+                                                      );
+
+                                                    if (
+                                                      nextValues !==
+                                                      selectedValues
+                                                    ) {
+                                                      field.onChange(
+                                                        nextValues,
+                                                      );
+                                                    }
+                                                    updateMultiselectInput(
+                                                      key,
+                                                      "",
+                                                    );
+                                                  }}
+                                                >
+                                                  {choice}
+                                                </CommandItem>
+                                              ))}
+                                            </CommandGroup>
+                                          </CommandList>
+                                        </Command>
+                                      </PopoverContent>
+                                    </Popover>
+                                  )}
+
+                                  {shouldShowOnlyTyping && (
+                                    <Input
+                                      id={`${key}-custom-item`}
+                                      placeholder={
+                                        value.placeholder ??
+                                        "Type an item and press Enter"
+                                      }
+                                      onKeyDown={(event) => {
+                                        if (event.key !== "Enter") return;
+
+                                        event.preventDefault();
+                                        const currentValues = selectedValues;
+                                        const nextValues = addMultiselectValue(
+                                          currentValues,
+                                          event.currentTarget.value,
+                                          value.maxSelectedChoices,
+                                        );
+
+                                        if (nextValues !== currentValues) {
+                                          field.onChange(nextValues);
+                                          event.currentTarget.value = "";
+                                        }
+                                      }}
+                                    />
+                                  )}
+                                </>
                               )}
                               {hasMinMax && (
                                 <span

--- a/packages/common/src/schemas.ts
+++ b/packages/common/src/schemas.ts
@@ -96,6 +96,7 @@ export const EditorialSchemaItemFieldSchema = z.looseObject({
   choicesFixed: z.array(z.string()).optional(),
   //backwards compatibility and will be removed in future versions
   isMultiple: z.boolean().optional(),
+  allowFreeInput: z.boolean().optional(),
   maxSelectedChoices: z.number().optional(),
   minSelectedChoices: z.number().optional(),
   isUploadedFile: z.boolean().optional(),


### PR DESCRIPTION
Adds `allowFreeInput` option to schema, allowing users to enter custom items in `select` and `multiselect` inputs.